### PR TITLE
fix:  parameter validation (min & max) for number and string types

### DIFF
--- a/src/Documentation/Request/Parameter.php
+++ b/src/Documentation/Request/Parameter.php
@@ -288,16 +288,23 @@ class Parameter implements OASSchematable
         }
 
         if ($this->type === self::TYPE_NUMBER || $this->type === self::TYPE_INTEGER) {
-            if (($this->min ?? null) && ($this->exclusiveMin ?? null)) {
+            if (null !== ($this->min ?? null) && null !== ($this->exclusiveMin ?? null)) {
                 $schema = $schema->exclusiveMinimum($this->min);
-            } elseif ($this->min ?? null) {
+            } elseif (null !== ($this->min ?? null)) {
                 $schema = $schema->minimum($this->min);
             }
 
-            if (($this->max ?? null) && ($this->exclusiveMax ?? null)) {
+            if (null !== ($this->max ?? null) && null !== ($this->exclusiveMax ?? null)) {
                 $schema = $schema->exclusiveMaximum($this->max);
-            } elseif ($this->max ?? null) {
+            } elseif (null !== ($this->max ?? null)) {
                 $schema = $schema->maximum($this->max);
+            }
+        } elseif($this->type === self::TYPE_STRING) {
+            if (null !== ($this->min ?? null)) {
+                $schema = $schema->minLength($this->min);
+            }
+            if (null !== ($this->max ?? null)) {
+                $schema = $schema->maxLength($this->max);
             }
         }
 

--- a/src/Parsers/Requests/Concerns/Rules/CommonRules.php
+++ b/src/Parsers/Requests/Concerns/Rules/CommonRules.php
@@ -512,7 +512,9 @@ trait CommonRules
      */
     public function parseMax(array $parameters): void
     {
-        $this->parameter->max((float)$parameters[0]);
+        if (is_numeric($parameters[0])) {
+            $this->parameter->max((float)$parameters[0]);
+        }
     }
 
     /**
@@ -536,7 +538,9 @@ trait CommonRules
      */
     public function parseMin(array $parameters): void
     {
-        $this->parameter->min((float)$parameters[0]);
+        if (is_numeric($parameters[0])) {
+            $this->parameter->min((float)$parameters[0]);
+        }
     }
 
     /**

--- a/tests/Concerns/AssertOpenApi.php
+++ b/tests/Concerns/AssertOpenApi.php
@@ -73,6 +73,8 @@ trait AssertOpenApi
         $clean($actual, 'example', null);
         $clean($expected, 'name', 'test');
         $clean($actual, 'name', 'test');
+        $clean($expected, 'description', '');
+        $clean($actual, 'description', '');
 
         $in = function (array $expected, array $actual, int $depth, string $path) use (&$in) {
             foreach ($expected as $key => $value) {


### PR DESCRIPTION
### Fixes
- parameter validation (min & max) for number and string types