### PR TITLE
v0.2

### DIFF
--- a/src/Contracts/CustomRuleParser.php
+++ b/src/Contracts/CustomRuleParser.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Ark4ne\OpenApi\Contracts;
+
+use Ark4ne\OpenApi\Documentation\Request\Parameter;
+use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+/**
+ * @deprecated rename to CustomRuleParserContract
+ */
+interface CustomRuleParser
+{
+    /**
+     * @param \Ark4ne\OpenApi\Documentation\Request\Parameter $parameter
+     * @param ValidationRule|Rule                             $rule
+     * @param string[]                                        $parameters
+     * @param array{rule: string|Rule, parameters:string[]}[] $rules
+     *
+     * @return void
+     */
+    public function parse(Parameter $parameter, ValidationRule|Rule $rule, array $parameters, array $rules): void;
+}

--- a/src/Contracts/CustomRuleParser.php
+++ b/src/Contracts/CustomRuleParser.php
@@ -4,16 +4,17 @@ namespace Ark4ne\OpenApi\Contracts;
 
 use Ark4ne\OpenApi\Documentation\Request\Parameter;
 use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Contracts\Validation\ValidationRule;
 
 interface CustomRuleParser
 {
     /**
      * @param \Ark4ne\OpenApi\Documentation\Request\Parameter $parameter
-     * @param \Illuminate\Contracts\Validation\Rule           $rule
+     * @param ValidationRule|Rule                             $rule
      * @param string[]                                        $parameters
      * @param array{rule: string|Rule, parameters:string[]}[] $rules
      *
      * @return void
      */
-    public function parse(Parameter $parameter, Rule $rule, array $parameters, array $rules): void;
+    public function parse(Parameter $parameter, ValidationRule|Rule $rule, array $parameters, array $rules): void;
 }

--- a/src/Contracts/CustomRuleParserContract.php
+++ b/src/Contracts/CustomRuleParserContract.php
@@ -6,7 +6,7 @@ use Ark4ne\OpenApi\Documentation\Request\Parameter;
 use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Contracts\Validation\ValidationRule;
 
-interface CustomRuleParser
+interface CustomRuleParserContract
 {
     /**
      * @param \Ark4ne\OpenApi\Documentation\Request\Parameter $parameter

--- a/src/Parsers/Rules/FieldsRuleParsers.php
+++ b/src/Parsers/Rules/FieldsRuleParsers.php
@@ -2,13 +2,13 @@
 
 namespace Ark4ne\OpenApi\Parsers\Rules;
 
-use Ark4ne\OpenApi\Contracts\CustomRuleParser;
+use Ark4ne\OpenApi\Contracts\CustomRuleParserContract;
 use Ark4ne\OpenApi\Documentation\Request\Component;
 use Ark4ne\OpenApi\Documentation\Request\Parameter;
 use Ark4ne\OpenApi\Support\Reflection;
 use Illuminate\Contracts\Validation\Rule;
 
-class FieldsRuleParsers implements CustomRuleParser
+class FieldsRuleParsers implements CustomRuleParserContract
 {
     /**
      * @param \Ark4ne\OpenApi\Documentation\Request\Parameter $parameter

--- a/src/Parsers/Rules/IncludesRuleParsers.php
+++ b/src/Parsers/Rules/IncludesRuleParsers.php
@@ -2,13 +2,13 @@
 
 namespace Ark4ne\OpenApi\Parsers\Rules;
 
-use Ark4ne\OpenApi\Contracts\CustomRuleParser;
+use Ark4ne\OpenApi\Contracts\CustomRuleParserContract;
 use Ark4ne\OpenApi\Documentation\Request\Component;
 use Ark4ne\OpenApi\Documentation\Request\Parameter;
 use Ark4ne\OpenApi\Support\Reflection;
 use Illuminate\Contracts\Validation\Rule;
 
-class IncludesRuleParsers implements CustomRuleParser
+class IncludesRuleParsers implements CustomRuleParserContract
 {
     /**
      * @param \Ark4ne\OpenApi\Documentation\Request\Parameter $parameter


### PR DESCRIPTION
### Fixes
- `CustomRuleParser` rename to `CustomRuleParserContract` (`CustomRuleParser` is not deleted but deprecated)
- `CustomRuleParserContract` now support `Illuminate\Contracts\Validation\ValidationRule` 